### PR TITLE
Update to zig 0.11.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,16 +9,19 @@ pub fn build(b: *std.build.Builder) void {
 
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+    const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable("DOOM-fire", "src/main.zig");
+    const exe = b.addExecutable(.{
+        .name = "DOOM-fire",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
     exe.linkLibC();
-    exe.setTarget(target);
-    exe.setBuildMode(mode);
-    exe.install();
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
     if (b.args) |args| {
         run_cmd.addArgs(args);
@@ -27,9 +30,12 @@ pub fn build(b: *std.build.Builder) void {
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
-    const exe_tests = b.addTest("src/main.zig");
-    exe_tests.setTarget(target);
-    exe_tests.setBuildMode(mode);
+    const exe_tests = b.addTest(.{
+        .name = "exe_tests",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&exe_tests.step);

--- a/src/main.zig
+++ b/src/main.zig
@@ -147,7 +147,7 @@ pub fn initColor() void {
 //get terminal size given a tty
 pub fn getTermSz(tty: std.os.fd_t) !TermSz {
     var winsz = c.winsize{ .ws_col = 0, .ws_row = 0, .ws_xpixel = 0, .ws_ypixel = 0 };
-    const rv = std.os.system.ioctl(tty, TIOCGWINSZ, @ptrToInt(&winsz));
+    const rv = std.os.system.ioctl(tty, TIOCGWINSZ, @intFromPtr(&winsz));
     const err = std.os.errno(rv);
     if (rv == 0) {
         return TermSz{ .height = winsz.ws_row, .width = winsz.ws_col };
@@ -502,8 +502,8 @@ pub fn paintBuf() void {
         bs_sz_avg = bs_sz_avg * (bs_frame_tic - 1) / bs_frame_tic + bs_len / bs_frame_tic;
     }
 
-    t_dur = @intToFloat(f64, t_now - t_start) / 1000.0;
-    fps = @intToFloat(f64, bs_frame_tic) / t_dur;
+    t_dur = @as(f64, @floatFromInt(t_now - t_start)) / 1000.0;
+    fps = @as(f64, @floatFromInt(bs_frame_tic)) / t_dur;
 
     emit(fg[0]);
     emitFmt("mem: {s:.2} min / {s:.2} avg / {s:.2} max [ {d:.2} fps ]", .{ std.fmt.fmtIntSizeBin(bs_sz_min), std.fmt.fmtIntSizeBin(bs_sz_avg), std.fmt.fmtIntSizeBin(bs_sz_max), fps });
@@ -516,8 +516,8 @@ pub fn freeBuf() void {
 
 pub fn showDoomFire() void {
     //term size => fire size
-    const FIRE_H: u16 = @intCast(u16, term_sz.height) * 2;
-    const FIRE_W: u16 = @intCast(u16, term_sz.width);
+    const FIRE_H: u16 = @as(u16, @intCast(term_sz.height)) * 2;
+    const FIRE_W: u16 = @as(u16, @intCast(term_sz.width));
     const FIRE_SZ: u16 = FIRE_H * FIRE_W;
     const FIRE_LAST_ROW: u16 = (FIRE_H - 1) * FIRE_W;
 


### PR DESCRIPTION
Reference: [Zig 0.11.0 Release Notes](https://ziglang.org/download/0.11.0/release-notes.html)

Tested on macOS Monterey 12.6.8 Intel x86_64.