### PR TITLE
Add Warp to the results

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ zig build run
 * kitty.app - great
 * Terminal.app - poor -- seems to drop framerates 
 * VS Code - great
+* Warp - great
 * Alacritty (artix linux) - great
 * Powershell/CMD 
 


### PR DESCRIPTION
I just tested iterm vs vscode vs warp on my machine (screen size: 153x36) and results surprised me (its almost 6x faster than iterm!), so i decided to share:

Warp ( https://www.warp.dev/ ) :
> mem: 18.08KiB min / 104.910KiB avg / 114.12KiB max [ 360.00 fps ]

VSCode:
> mem: 17.85KiB min / 105.92KiB avg / 111.82KiB max [ 86.11 fps ]

iTerm:
> mem: 17.99KiB min / 105.92KiB avg / 111.82KiB max [ 65.11 fps ]


Given all the above i recommend adding Warp rated as "great" after you verify that i did in fact test it correctly. 

PS. Decimals were different in min/avg/max but i had to write them down by hand so i ignored them in some cases, nothing malicious, just lazy :)