### PR TITLE
Fix integer overflow panic on large display

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -132,7 +132,7 @@ var bg: [MAX_COLOR][]u8 = undefined;
 
 // cache fg/bg ansi codes
 pub fn initColor() void {
-    var color_idx: u16 = 0;
+    var color_idx: u32 = 0;
     while (color_idx < MAX_COLOR) : (color_idx += 1) {
         fg[color_idx] = std.fmt.allocPrint(allocator, "{s}38;5;{d}m", .{ csi, color_idx }) catch unreachable;
         bg[color_idx] = std.fmt.allocPrint(allocator, "{s}48;5;{d}m", .{ csi, color_idx }) catch unreachable;
@@ -369,7 +369,7 @@ pub fn showGrayscale() void {
     var fg_idx: u8 = 15;
     emit(fg[fg_idx]);
 
-    var bg_idx: u16 = 232;
+    var bg_idx: u32 = 232;
     while (bg_idx < 256) : (bg_idx += 1) {
         if (bg_idx > 243) {
             fg_idx = 0;
@@ -548,10 +548,10 @@ pub fn freeBuf() void {
 
 pub fn showDoomFire() void {
     //term size => fire size
-    const FIRE_H: u16 = @as(u16, @intCast(term_sz.height)) * 2;
-    const FIRE_W: u16 = @as(u16, @intCast(term_sz.width));
-    const FIRE_SZ: u16 = FIRE_H * FIRE_W;
-    const FIRE_LAST_ROW: u16 = (FIRE_H - 1) * FIRE_W;
+    const FIRE_H: u32 = @as(u32, @intCast(term_sz.height)) * 2;
+    const FIRE_W: u32 = @as(u32, @intCast(term_sz.width));
+    const FIRE_SZ: u32 = FIRE_H * FIRE_W;
+    const FIRE_LAST_ROW: u32 = (FIRE_H - 1) * FIRE_W;
 
     //colors - tinker w/palette as needed!
     const fire_palette = [_]u8{ 0, 233, 234, 52, 53, 88, 89, 94, 95, 96, 130, 131, 132, 133, 172, 214, 215, 220, 220, 221, 3, 226, 227, 230, 195, 230 };
@@ -564,7 +564,7 @@ pub fn showDoomFire() void {
     defer allocator.free(screen_buf);
 
     //init buffer
-    var buf_idx: u16 = 0;
+    var buf_idx: u32 = 0;
     while (buf_idx < FIRE_SZ) : (buf_idx += 1) {
         screen_buf[buf_idx] = fire_black;
     }
@@ -583,22 +583,22 @@ pub fn showDoomFire() void {
 
     //scope cache ////////////////////
     //scope cache - update fire buf
-    var doFire_x: u16 = 0;
-    var doFire_y: u16 = 0;
-    var doFire_idx: u16 = 0;
+    var doFire_x: u32 = 0;
+    var doFire_y: u32 = 0;
+    var doFire_idx: u32 = 0;
 
     //scope cache - spread fire
     var spread_px: u8 = 0;
     var spread_rnd_idx: u8 = 0;
-    var spread_dst: u16 = 0;
+    var spread_dst: u32 = 0;
 
     //scope cache - frame reset
     const init_frame = std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ cursor_home, bg[0], fg[0] }) catch unreachable;
     defer allocator.free(init_frame);
 
     //scope cache - fire 2 screen buffer
-    var frame_x: u16 = 0;
-    var frame_y: u16 = 0;
+    var frame_x: u32 = 0;
+    var frame_y: u32 = 0;
     var px_hi: u8 = fire_black;
     var px_lo: u8 = fire_black;
     var px_prev_hi = px_hi;
@@ -711,7 +711,7 @@ const win32 = struct {
     pub const CONSOLE_SCREEN_BUFFER_INFO = extern struct {
         dwSize: COORD,
         dwCursorPosition: COORD,
-        wAttributes: u16,
+        wAttributes: u32,
         srWindow: SMALL_RECT,
         dwMaximumWindowSize: COORD,
     };


### PR DESCRIPTION
```
$ zig-out/bin/DOOM-fire
Screen size: 375w x 89h

Standard colors:
▏  0  ▏  1  ▏  2  ▏  3  ▏  4  ▏  5  ▏  6  ▏  7
▏  8  ▏  9  ▏ 10  ▏ 11  ▏ 12  ▏ 13  ▏ 14  ▏ 15

216 colors:
 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51
 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87
 88 89 90 91 92 93 94 95 96 97 98 99100101102103104105106107108109110111112113114115116117118119120121122123
124125126127128129130131132133134135136137138139140141142143144145146147148149150151152153154155156157158159
160161162163164165166167168169170171172173174175176177178179180181182183184185186187188189190191192193194195
196197198199200201202203204205206207208209210211212213214215216217218219220221222223224225226227228229230231

Grayscale:
▏232 ▏233 ▏234 ▏235 ▏236 ▏237 ▏238 ▏239 ▏240 ▏241 ▏242 ▏243 ▏244 ▏245 ▏246 ▏247 ▏248 ▏249 ▏250 ▏251 ▏252 ▏253 ▏254 ▏255

  How much is the fish?
             -- Scooter
Press return to continue...
thread 1068243 panic: integer overflow
/Users/sylvain/tmp/DOOM-fire-zig/src/main.zig:553:33: 0x104e7ab83 in showDoomFire (DOOM-fire)
    const FIRE_SZ: u16 = FIRE_H * FIRE_W;
                                ^
/Users/sylvain/tmp/DOOM-fire-zig/src/main.zig:695:17: 0x104e78d3b in main (DOOM-fire)
    showDoomFire();
                ^
/opt/homebrew/Cellar/zig/0.13.0/lib/zig/std/start.zig:524:37: 0x104e789d3 in main (DOOM-fire)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x19b517153 in ??? (???)
???:?:?: 0xa04fffffffffffff in ??? (???)
[1]    68669 abort      zig-out/bin/DOOM-fire
```