### PR TITLE
fix wrong terminal size on windows

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -717,7 +717,7 @@ const win32 = struct {
     pub const CONSOLE_SCREEN_BUFFER_INFO = extern struct {
         dwSize: COORD,
         dwCursorPosition: COORD,
-        wAttributes: u32,
+        wAttributes: u16,
         srWindow: SMALL_RECT,
         dwMaximumWindowSize: COORD,
     };


### PR DESCRIPTION
Looks like this commit broke getting the terminal size on windows:

342c47eb1ba371d37b9cbd1a1db85f7bbe3b6ad

They modified the size of the `wAttributes` field on `CONSOLE_SCREEN_BUFFER_INFO`. This appears to have been a mistake as it looks like they probably just did a search/replace of all the `u16` types with `u32`, however, we can't change the size of this field as it's defined by the OS and in doing so our `srWindow` offset is now incorrect.